### PR TITLE
Spec 138: Hybrid Performance Tracking (GitHub #152)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { createSignal, createEffect, createMemo, Show, Suspense, lazy, onCleanup } from 'solid-js'
+import { createSignal, createEffect, createMemo, Show, Suspense, lazy, onCleanup, onMount } from 'solid-js'
 import type { FromWorker, DisplayColumns, PrintingDisplayColumns, UniqueMode, BreakdownNode, Histograms, InstanceState, LineValidationResult } from '@frantic-search/shared'
 import type { DeckFormat } from '@frantic-search/shared'
 import { parse, toScryfallQuery, DEFAULT_LIST_ID, TRASH_LIST_ID } from '@frantic-search/shared'
@@ -24,7 +24,7 @@ import {
 } from './app-utils'
 import type { View } from './app-utils'
 import {
-  saveScrollPosition, pushIfNeeded, scheduleReplaceState,
+  saveScrollPosition, pushIfNeeded, pushStateAndCapturePageview, scheduleReplaceState,
   flushPendingCommit, cancelPendingCommit,
 } from './history-debounce'
 import { appendTerm, parseBreakdown, sealQuery, getMyListIdFromBreakdown } from './query-edit'
@@ -40,7 +40,7 @@ import {
   getMatchingCount,
   getUniqueTagsFromView,
 } from '@frantic-search/shared'
-import { captureUiInteracted } from './analytics'
+import { captureUiInteracted, capturePageview, captureFacesLoaded, capturePrintingsLoaded } from './analytics'
 import { useViewportWide } from './useViewportWide'
 const DualWieldLayout = lazy(() =>
   import('./DualWieldLayout').then((m) => ({ default: m.DualWieldLayout }))
@@ -72,6 +72,7 @@ const HEADER_ART_BLUR = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBD
 
 function App() {
   history.scrollRestoration = 'manual'
+  onMount(() => capturePageview())
   const viewportWide = useViewportWide()
 
   const initialParams = new URLSearchParams(location.search)
@@ -540,6 +541,9 @@ function App() {
         } else if (msg.status === 'atags-ready') {
           setIllustrationTagLabels(msg.tagLabels)
         } else if (msg.status === 'printings-ready') {
+          if (msg.printingsLoadDurationMs !== undefined) {
+            capturePrintingsLoaded({ duration_ms: msg.printingsLoadDurationMs })
+          }
           setPrintingDisplay(msg.printingDisplay)
           const view = cardListStore.getView()
           const listIds = [...new Set([...view.lists.keys(), TRASH_LIST_ID])]
@@ -550,6 +554,9 @@ function App() {
           }
         } else {
           if (msg.status === 'ready') {
+            if (msg.facesLoadDurationMs !== undefined) {
+              captureFacesLoaded({ duration_ms: msg.facesLoadDurationMs })
+            }
             setDataProgress(1)
             setDisplay(msg.display)
             setKeywordLabels(msg.keywordLabels ?? [])
@@ -789,6 +796,7 @@ function App() {
 
   window.addEventListener('popstate', () => {
     cancelPendingCommit()
+    capturePageview()
 
     const params = new URLSearchParams(location.search)
     setDualWieldActive(isDualWield(params))
@@ -824,7 +832,7 @@ function App() {
     if (docParamValue) params.set('doc', docParamValue)
     else params.set('doc', '')
     params.delete('help')
-    history.pushState(null, '', `?${params}`)
+    pushStateAndCapturePageview(`?${params}`)
     setDocParam(docParamValue ?? null)
     setView('docs')
     window.scrollTo(0, 0)
@@ -840,7 +848,7 @@ function App() {
     const params = new URLSearchParams()
     if (q) params.set('q', q)
     const url = params.toString() ? `?${params}` : location.pathname
-    history.pushState(null, '', url)
+    pushStateAndCapturePageview(url)
     setQuery(q)
     setQuery2('')
     setView('search')
@@ -854,7 +862,7 @@ function App() {
     params.delete('help')
     params.delete('doc')
     params.set('card', scryfallId)
-    history.pushState(null, '', `?${params}`)
+    pushStateAndCapturePageview(`?${params}`)
     setCardId(scryfallId)
     setView('card')
     window.scrollTo(0, 0)
@@ -872,7 +880,7 @@ function App() {
         : effectiveQuery().trim()
     if (q) params.set('q', q)
     params.set('report', '')
-    history.pushState(null, '', `?${params}`)
+    pushStateAndCapturePageview(`?${params}`)
     setView('report')
     window.scrollTo(0, 0)
   }
@@ -889,7 +897,7 @@ function App() {
     const params = new URLSearchParams()
     params.set('report', '')
     params.set('deck', '1')
-    history.pushState(null, '', `?${params}`)
+    pushStateAndCapturePageview(`?${params}`)
     setView('report')
     window.scrollTo(0, 0)
   }
@@ -900,7 +908,7 @@ function App() {
     captureUiInteracted({ element_name: 'lists', action: 'clicked' })
     const params = new URLSearchParams()
     params.set('list', tab === 'trash' ? 'trash' : '')
-    history.pushState(null, '', `?${params}`)
+    pushStateAndCapturePageview(`?${params}`)
     setListTab(tab)
     setView('lists')
     window.scrollTo(0, 0)
@@ -909,7 +917,7 @@ function App() {
   function navigateToListsTab(tab: 'default' | 'trash') {
     const params = new URLSearchParams(location.search)
     params.set('list', tab === 'trash' ? 'trash' : '')
-    history.pushState(null, '', `?${params}`)
+    pushStateAndCapturePageview(`?${params}`)
     setListTab(tab)
   }
 
@@ -923,7 +931,7 @@ function App() {
     params.delete('q')
     params.set('q1', current)
     params.set('q2', right)
-    history.pushState(null, '', `?${params}`)
+    pushStateAndCapturePageview(`?${params}`)
     setDualWieldActive(true)
     setQuery(current)
     setQuery2(right)
@@ -944,7 +952,7 @@ function App() {
     params.delete('q1')
     params.delete('q2')
     const url = params.toString() ? `?${params}` : location.pathname
-    history.pushState(null, '', url)
+    pushStateAndCapturePageview(url)
     setDualWieldActive(false)
     setQuery2('')
     setView('search')
@@ -1014,13 +1022,13 @@ function App() {
         if (qVal.trim() !== '') {
           // First tap: q=foo → q= (empty)
           params.set('q', '')
-          history.pushState(null, '', params.toString() ? `?${params}` : location.pathname)
+          pushStateAndCapturePageview(params.toString() ? `?${params}` : location.pathname)
           setQuery('')
           setUserEngaged(true)
         } else {
           // Second tap: q= → remove q (parameterless)
           params.delete('q')
-          history.pushState(null, '', params.toString() ? `?${params}` : location.pathname)
+          pushStateAndCapturePageview(params.toString() ? `?${params}` : location.pathname)
           setQuery('')
           setUserEngaged(false)
           setUrlHasQueryParam(false)
@@ -1045,7 +1053,7 @@ function App() {
     // Not at home — soft reset to initial state
     cancelPendingCommit()
     saveScrollPosition()
-    history.pushState(null, '', location.pathname)
+    pushStateAndCapturePageview(location.pathname)
     setDualWieldActive(false)
     setQuery('')
     setQuery2('')
@@ -1286,7 +1294,7 @@ function App() {
             if (dp) params.set('doc', dp)
             else params.set('doc', '')
             params.delete('help')
-            history.pushState(null, '', `?${params}`)
+            pushStateAndCapturePageview(`?${params}`)
             setDocParam(dp)
             window.scrollTo(0, 0)
           }}

--- a/app/src/analytics.ts
+++ b/app/src/analytics.ts
@@ -9,6 +9,7 @@ if (!import.meta.env.DEV) {
       persistence: 'memory',
       autocapture: false,
       capture_pageview: false,
+      capture_performance: true,
       transport: 'fetch',
     } as Parameters<typeof posthog.init>[1])
   }
@@ -28,4 +29,16 @@ export function captureUiInteracted(params: {
   state?: string
 }): void {
   posthog.capture('ui_interacted', params)
+}
+
+export function capturePageview(): void {
+  posthog.capture('$pageview')
+}
+
+export function captureFacesLoaded(params: { duration_ms: number }): void {
+  posthog.capture('faces_loaded', params)
+}
+
+export function capturePrintingsLoaded(params: { duration_ms: number }): void {
+  posthog.capture('printings_loaded', params)
 }

--- a/app/src/history-debounce.ts
+++ b/app/src/history-debounce.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { capturePageview } from './analytics'
 
 const HISTORY_DEBOUNCE_MS = 2000
 const REPLACE_DEBOUNCE_MS = 200
@@ -23,12 +24,17 @@ export function saveScrollPosition() {
   history.replaceState({ ...history.state, scrollY: window.scrollY }, '')
 }
 
+export function pushStateAndCapturePageview(url: string, state?: object | null): void {
+  history.pushState(state ?? null, '', url)
+  capturePageview()
+}
+
 export function pushIfNeeded() {
   if (!needsPush) return
   needsPush = false
   clearReplaceDebounce()
   saveScrollPosition()
-  history.pushState(history.state, '', location.href)
+  pushStateAndCapturePageview(location.href, history.state)
 }
 
 export function scheduleReplaceState(url: string) {

--- a/app/src/worker.ts
+++ b/app/src/worker.ts
@@ -189,6 +189,7 @@ async function fetchColumns(url: URL): Promise<FetchResult> {
 }
 
 async function init(): Promise<void> {
+  self.performance.mark('worker-init-start')
   post({ type: 'status', status: 'loading' })
 
   const printingsPromise = fetchPrintings()
@@ -246,10 +247,23 @@ async function init(): Promise<void> {
   const displayRef = extractDisplayColumns(data)
   const printingDisplayRef = printingData ? extractPrintingDisplayColumns(printingData) : null
 
-  post({ type: 'status', status: 'ready', display: displayRef, keywordLabels: Object.keys(keywordsIndex) })
+  const facesMeasure = self.performance.measure('faces-load', 'worker-init-start')
+  post({
+    type: 'status',
+    status: 'ready',
+    display: displayRef,
+    keywordLabels: Object.keys(keywordsIndex),
+    facesLoadDurationMs: Math.round(facesMeasure.duration),
+  })
 
   if (printingData) {
-    post({ type: 'status', status: 'printings-ready', printingDisplay: printingDisplayRef! })
+    const printingsMeasure = self.performance.measure('printings-load', 'worker-init-start')
+    post({
+      type: 'status',
+      status: 'printings-ready',
+      printingDisplay: printingDisplayRef!,
+      printingsLoadDurationMs: Math.round(printingsMeasure.duration),
+    })
   }
 
   function serializeList(

--- a/docs/specs/138-hybrid-performance-tracking.md
+++ b/docs/specs/138-hybrid-performance-tracking.md
@@ -1,6 +1,6 @@
 # Spec 138: Hybrid Performance Tracking
 
-**Status:** Draft
+**Status:** In Progress
 
 **Implements:** [GitHub #152](https://github.com/jimbojw/frantic-search/issues/152)
 

--- a/shared/src/worker-protocol.ts
+++ b/shared/src/worker-protocol.ts
@@ -99,8 +99,8 @@ export type PrintingDisplayColumns = {
 export type FromWorker =
   | { type: 'status'; status: 'loading' }
   | { type: 'status'; status: 'progress'; fraction: number }
-  | { type: 'status'; status: 'ready'; display: DisplayColumns; keywordLabels?: string[] }
-  | { type: 'status'; status: 'printings-ready'; printingDisplay: PrintingDisplayColumns }
+  | { type: 'status'; status: 'ready'; display: DisplayColumns; keywordLabels?: string[]; facesLoadDurationMs?: number }
+  | { type: 'status'; status: 'printings-ready'; printingDisplay: PrintingDisplayColumns; printingsLoadDurationMs?: number }
   | { type: 'status'; status: 'otags-ready'; tagLabels: string[] }
   | { type: 'status'; status: 'atags-ready'; tagLabels: string[] }
   | { type: 'status'; status: 'error'; error: string; cause: 'stale' | 'network' | 'unknown' }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [GitHub #152](https://github.com/jimbojw/frantic-search/issues/152) — hybrid performance tracking for PostHog.

## Changes

### Spec 138 (`docs/specs/138-hybrid-performance-tracking.md`)
- Status: Draft → In Progress

### PostHog (`app/src/analytics.ts`)
- Add `capture_performance: true` for FCP/LCP
- Add `capturePageview()`, `captureFacesLoaded()`, `capturePrintingsLoaded()`

### Centralized pushState (`app/src/history-debounce.ts`)
- Add `pushStateAndCapturePageview(url, state?)` — single code path for push + pageview
- Update `pushIfNeeded()` to use it (debounced commits fire pageview)

### App (`app/src/App.tsx`)
- Replace all `history.pushState` with `pushStateAndCapturePageview`
- Fire `capturePageview()` on mount (initial load) and in `popstate` handler
- Fire `captureFacesLoaded` / `capturePrintingsLoaded` when worker sends duration

### Worker (`app/src/worker.ts`)
- `performance.mark('worker-init-start')` at init
- `performance.measure()` for faces and printings milestones
- Include `facesLoadDurationMs` and `printingsLoadDurationMs` in status messages

### Worker protocol (`shared/src/worker-protocol.ts`)
- Add optional `facesLoadDurationMs?` to `status: 'ready'`
- Add optional `printingsLoadDurationMs?` to `status: 'printings-ready'`

## Acceptance criteria

- [x] PostHog init includes `capture_performance: true`
- [x] Typing (replaceState) does not fire `$pageview`
- [x] Initial load fires `$pageview`
- [x] Every pushState (including debounced) fires `$pageview`
- [x] popstate fires `$pageview`
- [x] Worker sends durations; main thread fires `faces_loaded` and `printings_loaded`
- [x] `search_executed` unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7afc5f3c-10e7-4f02-825e-aed4291ed7c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7afc5f3c-10e7-4f02-825e-aed4291ed7c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

