### PR TITLE
fix: include name: and n: field terms in starts-with priority sorting (Issue #86)

### DIFF
--- a/docs/specs/019-relevance-boosted-ordering.md
+++ b/docs/specs/019-relevance-boosted-ordering.md
@@ -51,16 +51,21 @@ The existing `fnv1a` function is reused for seed derivation. `mulberry32` is no 
 
 ### Bare-word extraction from the AST
 
-To determine which cards get a prefix boost, the sort needs to know what name-related terms the user typed. A walk of the AST collects all `BARE` node values that are not under a `NOT`:
+To determine which cards get a prefix boost, the sort needs to know what name-related terms the user typed. A walk of the AST collects all `BARE` node values and `name:`/`n:` field values (substring operators `:` and `=`) that are not under a `NOT` (Issue #86):
 
 ```typescript
 function collectBareWords(ast: ASTNode): string[] {
   switch (ast.type) {
     case "BARE": return [ast.value];
+    case "FIELD":
+      if (ast.value && (ast.operator === ":" || ast.operator === "=") &&
+          FIELD_ALIASES[ast.field.toLowerCase()] === "name")
+        return [ast.value];
+      return [];
     case "AND":
     case "OR":   return ast.children.flatMap(collectBareWords);
     case "NOT":  return [];   // negated terms are exclusions, not search intent
-    default:     return [];   // FIELD, EXACT, REGEX_FIELD don't signal name search
+    default:     return [];   // EXACT, REGEX_FIELD don't signal name search
   }
 }
 ```
@@ -68,6 +73,8 @@ function collectBareWords(ast: ASTNode): string[] {
 | Query | AST structure | Extracted terms | Boost behavior |
 |---|---|---|---|
 | `light` | `BARE("light")` | `["light"]` | startsWith "light" |
+| `name:bolt` | `FIELD("name", ":", "bolt")` | `["bolt"]` | startsWith "bolt" |
+| `n:bolt` | `FIELD("n", ":", "bolt")` | `["bolt"]` | startsWith "bolt" |
 | `light t:creature` | `AND(BARE, FIELD)` | `["light"]` | startsWith "light" |
 | `light bolt` | `AND(BARE, BARE)` | `["light", "bolt"]` | startsWith either |
 | `light OR bolt` | `OR(BARE, BARE)` | `["light", "bolt"]` | startsWith either |
@@ -263,6 +270,8 @@ These signals could be added as additional sort tiers between the prefix tier an
 5. Mixed: `AND(NOT(BARE("fire")), BARE("bolt"))` → `["bolt"]`.
 6. No bare words: `AND(FIELD("t","creature"), FIELD("c","red"))` → `[]`.
 7. OR of bare words: `OR(BARE("light"), BARE("bolt"))` → `["light", "bolt"]`.
+8. name: field (Issue #86): `FIELD("name", ":", "bolt")` → `["bolt"]`; `FIELD("n", ":", "bolt")` → `["bolt"]`.
+9. Negated name: field: `NOT(FIELD("name", ":", "bolt"))` → `[]`.
 
 **`seededSort`:**
 1. **Prefix boost**: Given names `["Lightning Bolt", "Twilight Shepherd", "Lightmine Field"]` and bare word `"light"`, the two names starting with "light" appear before "Twilight Shepherd".

--- a/shared/src/search/ordering.test.ts
+++ b/shared/src/search/ordering.test.ts
@@ -110,6 +110,27 @@ describe("collectBareWords", () => {
     );
     expect(collectBareWords(ast)).toEqual([]);
   });
+
+  test("name: field terms are collected (Issue #86)", () => {
+    expect(collectBareWords(field("name", ":", "bolt"))).toEqual(["bolt"]);
+    expect(collectBareWords(and(field("name", ":", "bolt"), field("t", ":", "instant")))).toEqual(["bolt"]);
+  });
+
+  test("n: alias is collected (Issue #86)", () => {
+    expect(collectBareWords(field("n", ":", "bolt"))).toEqual(["bolt"]);
+  });
+
+  test("name= field terms are collected", () => {
+    expect(collectBareWords(field("name", "=", "Lightning"))).toEqual(["Lightning"]);
+  });
+
+  test("negated name: field yields nothing", () => {
+    expect(collectBareWords(not(field("name", ":", "bolt")))).toEqual([]);
+  });
+
+  test("name: and bare word both collected", () => {
+    expect(collectBareWords(and(bare("light"), field("name", ":", "bolt")))).toEqual(["light", "bolt"]);
+  });
 });
 
 // --- seededSort ---

--- a/shared/src/search/ordering.ts
+++ b/shared/src/search/ordering.ts
@@ -3,6 +3,7 @@ import type { ASTNode, SortDirective } from "./ast";
 import type { CardIndex } from "./card-index";
 import type { PrintingIndex } from "./printing-index";
 import { RARITY_ORDER } from "../bits";
+import { FIELD_ALIASES } from "./eval-leaves";
 
 export function fnv1a(str: string): number {
   let h = 0x811c9dc5;
@@ -25,14 +26,26 @@ export function seededRank(seedHash: number, index: number): number {
   return (h ^ (h >>> 16)) >>> 0;
 }
 
+const NAME_SUBSTRING_OPS = new Set([":", "="]);
+
 /**
- * Walk the AST and collect values from BARE nodes that are not under a NOT.
- * These represent the user's name-search intent for prefix boosting.
+ * Walk the AST and collect values from BARE nodes and name-field terms
+ * (name:value, n:value) that are not under a NOT. These represent the
+ * user's name-search intent for prefix boosting (Issue #86).
  */
 export function collectBareWords(ast: ASTNode): string[] {
   switch (ast.type) {
     case "BARE":
       return [ast.value];
+    case "FIELD":
+      if (
+        ast.value &&
+        NAME_SUBSTRING_OPS.has(ast.operator) &&
+        FIELD_ALIASES[ast.field.toLowerCase()] === "name"
+      ) {
+        return [ast.value];
+      }
+      return [];
     case "AND":
     case "OR":
       return ast.children.flatMap(collectBareWords);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #86. The "starts with" priority sorting previously only considered bare words (e.g. `bolt`) for prefix boosting. Queries like `name:bolt` or `n:bolt` did not prioritize cards whose names start with "bolt" (e.g. Bolt Hound).

## Changes

- **`shared/src/search/ordering.ts`**: Extended `collectBareWords` to also collect values from `FIELD` nodes where the field is `name` or `n` (alias) and the operator is `:` or `=` (substring semantics). Negated `name:` terms under `NOT` are excluded, same as bare words.
- **`shared/src/search/ordering.test.ts`**: Added tests for `name:bolt`, `n:bolt`, `name=Lightning`, negated `name:`, and mixed bare + name: terms.
- **`docs/specs/019-relevance-boosted-ordering.md`**: Updated spec to document the new behavior.

## Verification

All 63 ordering tests pass, including the 5 new tests for name-field collection.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c18d9604-3836-487b-b2b5-4bac51ddf9d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c18d9604-3836-487b-b2b5-4bac51ddf9d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

