### PR TITLE
fix(app): oracle suggestions sort before otag/atag bare-term upgrades

### DIFF
--- a/app/src/worker-search.test.ts
+++ b/app/src/worker-search.test.ts
@@ -1,6 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest'
 import { NodeCache, index, printingIndex, TEST_DATA, TEST_PRINTING_DATA, CardFlag, Format } from '@frantic-search/shared'
+import type { OracleTagData } from '@frantic-search/shared'
+
+const FIXTURE_ORACLE_TAGS: OracleTagData = {
+  ramp: [0, 3, 4],
+}
+const tagDataForOtagTests = {
+  oracle: FIXTURE_ORACLE_TAGS,
+  illustration: null,
+  flavor: null,
+  artist: null,
+} as const
 import { CardIndex } from '@frantic-search/shared'
 import { PrintingIndex } from '@frantic-search/shared'
 import { emptyUrlLiveQuerySuggestionPool } from './worker-empty-url-suggestions'
@@ -585,6 +596,7 @@ describe('oracle hint (Spec 131)', () => {
     expect(oracle!.query).toContain('o:')
     expect(oracle!.label).toContain('o:')
     expect(oracle!.count).toBeGreaterThan(0)
+    expect(oracle!.priority).toBe(20)
   })
 
   it('(xyc OR abc) with zero results does not trigger oracle suggestion', () => {
@@ -609,6 +621,42 @@ describe('oracle hint (Spec 131)', () => {
     })
     expect(result.indices.length).toBeGreaterThan(0)
     expect(result.suggestions.find((s) => s.id === 'oracle')).toBeUndefined()
+  })
+
+  it('otag bare-term-upgrade uses priority 21 (Spec 151; sorts after oracle 20)', () => {
+    const cacheWithTags = new NodeCache(index, printingIndex, null, {
+      oracle: FIXTURE_ORACLE_TAGS,
+      illustration: null,
+      flavor: null,
+      artist: null,
+    })
+    const result = runSearch({
+      msg: { type: 'search', queryId: 1, query: 'ramp' },
+      cache: cacheWithTags,
+      index,
+      printingIndex,
+      sessionSalt,
+      tagData: tagDataForOtagTests,
+    })
+    expect(result.indices.length).toBe(0)
+    const otagChip = result.suggestions.find((s) => s.id === 'bare-term-upgrade' && s.label === 'otag:ramp')
+    expect(otagChip).toBeDefined()
+    expect(otagChip!.priority).toBe(21)
+  })
+
+  it('kw bare-term-upgrade stays priority 16 (before oracle and otag chips)', () => {
+    const result = runSearch({
+      msg: { type: 'search', queryId: 1, query: 'landfall' },
+      cache,
+      index,
+      printingIndex,
+      sessionSalt,
+      keywordLabels: ['landfall'],
+    })
+    expect(result.indices.length).toBe(0)
+    const kwChip = result.suggestions.find((s) => s.id === 'bare-term-upgrade' && s.label === 'kw:landfall')
+    expect(kwChip).toBeDefined()
+    expect(kwChip!.priority).toBe(16)
   })
 })
 

--- a/app/src/worker-suggestions.ts
+++ b/app/src/worker-suggestions.ts
@@ -26,6 +26,13 @@ import { hasListSyntaxInQuery, collectListOffendingTerms, appendTerm, spliceQuer
 import { spliceBareToOracle, getOracleLabel } from './oracle-hint-edit'
 import { evaluateAlternative } from './worker-alternative-eval'
 
+/** Spec 151: `otag:` / `atag:` bare-term-upgrade chips sort after oracle (20). */
+function bareTermUpgradePriority(label: string): 16 | 21 {
+  const lower = label.toLowerCase()
+  if (lower.startsWith('otag:') || lower.startsWith('atag:')) return 21
+  return 16
+}
+
 export type BuildSuggestionsParams = {
   msg: { query: string; pinnedQuery?: string; viewMode?: 'slim' | 'detail' | 'images' | 'full' }
   ast: ASTNode
@@ -233,7 +240,7 @@ export function buildSuggestions(params: BuildSuggestionsParams): Suggestion[] {
           explain: alt.explain,
           ...(cardCount > 0 ? { count: cardCount, printingCount } : {}),
           docRef: alt.docRef,
-          priority: 16,
+          priority: bareTermUpgradePriority(alt.label),
           variant: 'rewrite',
         })
       }
@@ -275,7 +282,7 @@ export function buildSuggestions(params: BuildSuggestionsParams): Suggestion[] {
           explain: alt.explain,
           ...(cardCount > 0 ? { count: cardCount, printingCount } : {}),
           docRef: alt.docRef,
-          priority: 16,
+          priority: bareTermUpgradePriority(alt.label),
           variant: 'rewrite',
         })
         bareTermUpgradedValues.add(node.value.toLowerCase())

--- a/docs/specs/131-oracle-did-you-mean.md
+++ b/docs/specs/131-oracle-did-you-mean.md
@@ -121,6 +121,8 @@ Queries like `t:creature` or `(xyc OR abc)` with zero results do not trigger the
 
 **Current location (post–Spec 151, worker refactor):** Oracle suggestion is built in `buildSuggestions` (app/src/worker-suggestions.ts), using `evaluateAlternative` from app/src/worker-alternative-eval.ts. Delivered via `suggestions` array (id: 'oracle').
 
+**Sort order vs tag chips:** When the same query also produces `bare-term-upgrade` chips for **`otag:`** or **`atag:`** (Spec 154 / 159), the unified list is sorted by `priority`; oracle uses **20** and those tag chips use **21** (Spec 151), so the oracle rewrite appears first.
+
 ## Acceptance Criteria
 
 - [ ] When `lightning ci:r deal 3` returns zero and the phrase variant returns results, the hint shows `lightning ci:r o:"deal 3"`.

--- a/docs/specs/151-suggestion-system.md
+++ b/docs/specs/151-suggestion-system.md
@@ -110,13 +110,14 @@ When the empty state has *no* context-specific suggestions (no include-extras, o
 |----|----------|-----------|
 | empty-list | 0 | Highest — user cannot get results without a list |
 | nonexistent-field | 14 | Mistaken field name not in Scryfall; registry maps to a real field (Spec 158). Before bare-term-upgrade — invalid field clause is a hard engine error |
-| oracle | 20 | Reformulates bare tokens to oracle search |
+| bare-term-upgrade | 16 | Bare term matches a **non-tag** domain (kw:, t:, set:, f:, is:, game:, frame:, rarity:). Spec 154. |
+| (future) card-type | 15 | Type token reformulation; before oracle (e.g. "creatures" → t:creature) |
+| oracle | 20 | Reformulates bare tokens to oracle search (Spec 131). **Sorts before** `otag:` / `atag:` bare-term-upgrade chips (priority 21) when both apply. |
+| bare-term-upgrade (otag/atag only) | 21 | Same `id` as other bare-term upgrades; label starts with `otag:` or `atag:` (Spec 154 exact + Spec 159 prefix). Lower priority than oracle so the oracle-text hint appears first. |
 | wrong-field | 22 | Right value in wrong field; suggest correct field (Spec 153) |
 | stray-comma | 23 | Remove value-terminal commas mistaken for clause separators; Spec 157 |
 | relaxed | 24 | Color / identity `=` → `:` / `>=` when exact match is too strict; Spec 156 |
 | unique-prints | 30 | Rider context; expand printings |
-| bare-term-upgrade | 16 | Bare term matches known field value; suggest field prefix (e.g. "landfall" → kw:landfall). Spec 154. |
-| (future) card-type | 15 | Type token reformulation; before oracle (e.g. "creatures" → t:creature) |
 | artist-atag | 25 | Cross-detect atag vs a; suggest the field that returns results. Unified by Spec 153. |
 | (future) near-miss | 18 | Unquoted multi-word field value; suggest quoted form when it would match |
 | example-query | 40 | Fallback — when no other empty-state suggestion applies; ensures we never fail silently |
@@ -183,7 +184,7 @@ Each future trigger gets its own spec. This document records the intended ids an
 ## Implementation notes
 
 - **Worker suggestion building:** `runSearch` calls `buildSuggestions(params)` from `app/src/worker-suggestions.ts`. That module receives `getListMask` via params. For empty-list: when `hasListSyntaxInQuery(effectiveBd)` and `getListMask("default")` is empty, push one Suggestion per term from `collectListOffendingTerms(effectiveBd)` (label = term, emptyListVariant = 'my' or 'tag'). No totalCards constraint.
-- **Bare-term-upgrade (Spec 154):** In `buildSuggestions`, when totalCards === 0, call `getBareNodes(ast)` to collect positive BARE nodes; for each, `getBareTermAlternatives(value, context)` returns matching domains; splice and evaluate each alternative; suggest those with count > 0. Runs before oracle; terms that received a bare-term-upgrade are excluded when building the oracle hint. **Multi-word:** sliding-window pass calls `getMultiWordAlternatives` for adjacent bare windows (keywords, artists); **Spec 159** adds tag **prefix** matching for `otag:` / `atag:` on those windows (hyphen slug) and on **single** bare tokens (`getBareTagPrefixAlternatives`), deduped against exact `otag:`/`atag:` chips.
+- **Bare-term-upgrade (Spec 154):** In `buildSuggestions`, when totalCards === 0, call `getBareNodes(ast)` to collect positive BARE nodes; for each, `getBareTermAlternatives(value, context)` returns matching domains; splice and evaluate each alternative; suggest those with count > 0. Runs before oracle; terms that received a bare-term-upgrade are excluded when building the oracle hint. **Multi-word:** sliding-window pass calls `getMultiWordAlternatives` for adjacent bare windows (keywords, artists); **Spec 159** adds tag **prefix** matching for `otag:` / `atag:` on those windows (hyphen slug) and on **single** bare tokens (`getBareTagPrefixAlternatives`), deduped against exact `otag:`/`atag:` chips. **Priority:** non–tag domains use **16**; suggestions whose label is `otag:`… or `atag:`… use **21** so they sort after the oracle hint (**20**).
 - **Wrong-field (Spec 153):** Unified by Spec 153. In `buildSuggestions`, when totalCards === 0, walk effectiveBd for FIELD/NOT nodes with trigger fields (is:, in:, type:) and known color values; suggest ci:/c:/produces: alternatives that return > 0. Uses `evaluateAlternative` from `worker-alternative-eval.ts`.
 - **Artist-atag (Spec 153):** In `buildSuggestions`, when totalCards === 0, walk for a:/artist: and atag:/art: nodes; try swapped field; suggest if count > 0.
 - **include-extras rider trigger:** `indicesIncludingExtras` defined and `(indicesIncludingExtras - totalCards) > 0`.

--- a/docs/specs/154-bare-term-field-upgrade-suggestions.md
+++ b/docs/specs/154-bare-term-field-upgrade-suggestions.md
@@ -41,7 +41,7 @@ All of the following must hold:
 All suggestions in this category use `id: 'bare-term-upgrade'`. Each suggestion is a single chip: label = the new term (e.g. `kw:landfall`), query = full query with that term spliced in, explain = teaching copy.
 
 - **Placement:** Empty state only (below Results Summary Bar, alongside oracle, wrong-field, etc.).
-- **Priority:** 16 (Spec 151: higher than oracle 20 — field-specific upgrades are narrower than generic oracle, so show first).
+- **Priority:** **16** for kw:, t:, set:, f:, is:, game:, frame:, and rarity: upgrades (Spec 151). **`otag:`** and **`atag:`** upgrades (exact + Spec 159 prefix) use **21** so they sort **after** the oracle “did you mean” hint (**20**) when both appear; other suggestion priorities are unchanged.
 - **Variant:** `rewrite`.
 - **Negation:** Only positive BARE nodes. Negated bare terms are not converted (same as Spec 131).
 
@@ -55,7 +55,7 @@ All suggestions in this category use `id: 'bare-term-upgrade'`. Each suggestion 
 
 When a bare term matches **multiple** domains (e.g. `commander` matches format and is:), suggest each matching domain. Order: keyword → type-line → set → format → is: → otag → atag → game → frame → rarity. Only the first matching domain is required for MVP; others can be added incrementally.
 
-**Interaction with oracle (Spec 131):** When a bare term matches both a field domain (e.g. `kw:landfall`) and the oracle fallback (`o:landfall`), prefer the **field-specific** suggestion. The bare-term-upgrade suggestion (priority 16) will outrank oracle (priority 20). We show at most one suggestion per bare term — if `kw:landfall` returns results, we suggest that and do not also suggest `o:landfall` for that term. The oracle hint logic runs after bare-term-upgrade; if a bare term already produced a bare-term-upgrade suggestion, skip it for oracle. (Implementation: evaluate bare-term upgrades first; for terms that got a suggestion, do not feed them to the oracle path.)
+**Interaction with oracle (Spec 131):** When a bare term matches both a **non-tag** field domain (e.g. `kw:landfall`) and the oracle fallback (`o:landfall`), prefer the **field-specific** suggestion. That bare-term-upgrade row uses priority **16** and sorts **before** oracle (**20**). We show at most one suggestion per bare term — if `kw:landfall` returns results, we suggest that and do not also suggest `o:landfall` for that term. The oracle hint logic runs after bare-term-upgrade; if a bare term already produced a bare-term-upgrade suggestion, skip it for oracle. (Implementation: evaluate bare-term upgrades first; for terms that got a suggestion, do not feed them to the oracle path.) **`otag:`** / **`atag:`** bare-term-upgrade chips use priority **21** (Spec 151): when both oracle and tag chips appear (e.g. trailing bare `ramp` with tag data loaded), the oracle hint sorts **first**.
 
 ### Domains
 
@@ -297,7 +297,7 @@ Add `'bare-term-upgrade'` to the `Suggestion.id` union in `shared/src/suggestion
 5. `lightning ci:r landfall` with zero results shows `kw:landfall` chip (replacing only "landfall"); tapping produces `lightning ci:r kw:landfall`.
 6. `landfall f:commander` with zero results shows `kw:landfall` chip (non-trailing bare term); tapping produces `kw:landfall f:commander`.
 7. `landfall flying` with zero results shows both `kw:landfall` and `kw:flying` chips (counts may be 0).
-8. Bare-term-upgrade suggestions appear below the Results Summary Bar, before oracle suggestions when both could apply.
+8. Bare-term-upgrade suggestions appear below the Results Summary Bar. **Non-tag** upgrades (priority 16) sort before the oracle hint (20). **`otag:`** / **`atag:`** upgrades (21) sort after the oracle hint when both apply.
 9. When a bare term gets a bare-term-upgrade suggestion, the oracle hint does not also suggest `o:{term}` for that same term.
 10. Works in single-pane and Dual Wield layouts.
 11. Each chip shows explain text and "Learn more" link when docRef is set.

--- a/docs/specs/159-otag-atag-hyphen-multiword-suggestions.md
+++ b/docs/specs/159-otag-atag-hyphen-multiword-suggestions.md
@@ -111,7 +111,7 @@ The single-node pass runs **`getBareTermAlternatives`** first (exact match for `
 ### Suggestion model
 
 - **`id`:** `bare-term-upgrade` (no new id).
-- **Priority:** **16** (unchanged; Spec 151).
+- **Priority:** **21** for these `otag:` / `atag:` chips (Spec 151) so they sort after the oracle hint (**20**). Other bare-term-upgrade domains remain at **16**.
 - **Placement:** Empty state only.
 - **Label:** `otag:{key}` or `atag:{key}` with canonical key from data.
 - **Explain:** Reuse Spec 154 otag/atag explain strings (“Use otag: for oracle tags.” / “Use atag: for illustration tags.”) and **docRef** (`reference/fields/face/otag`, `reference/fields/face/atag`).
@@ -150,7 +150,7 @@ The single-node pass runs **`getBareTermAlternatives`** first (exact match for `
 3. Tapping a chip applies the same rewrite path as other bare-term upgrades (Spec 151).
 4. When oracle tag data is missing, no `otag:` suggestion is produced for hyphen windows; illustration tag data gated similarly for `atag:`.
 5. At most three `otag:` suggestions and at most three `atag:` suggestions per multi-word window from tag prefix logic.
-6. Spec 154 is updated to reference this spec for otag/atag multi-word behavior; Spec 151 needs **no** new `id` or priority row (optional short cross-link under bare-term-upgrade notes).
+6. Spec 154 is updated to reference this spec for otag/atag multi-word behavior; Spec 151 documents **`bare-term-upgrade` priority 21** for `otag:` / `atag:` labels (oracle hint remains **20**).
 7. Bare query `triggere` (zero results, tag data loaded, `triggered-ability` in oracle labels) yields a **`bare-term-upgrade`** suggestion **`otag:triggered-ability`** (single-token prefix).
 8. When exact `otag:` / `atag:` already matches for a single bare token, no duplicate chip for the same tag from the prefix pass.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **`bare-term-upgrade` suggestions** whose label starts with `otag:` or `atag:` now use **priority 21**; all other bare-term upgrades stay at **16**; **`oracle` stays 20**, so the unified list sorts oracle before tag chips when both appear.
- **Specs updated:** 131 (sort note), 151 (priority table + implementation note), 154 (priority + interaction + acceptance), 159 (priority + acceptance).
- **Tests:** assert `otag:ramp` chip is priority 21 with tag data; `kw:landfall` stays 16; existing oracle hint test now checks priority 20.

## Note

An end-to-end case where **both** oracle and `otag:` fire on the same query is still constrained by Spec 154 consumption (trailing bare that gets `otag:` is excluded from the oracle path). This change fixes **ordering** whenever both suggestion kinds are emitted; it does not change consumption.

## Suggested review

- Confirm priority **21** sits correctly between oracle (**20**) and wrong-field (**22**).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adbe6e59-b15d-4ff6-a51e-728e3a951a1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adbe6e59-b15d-4ff6-a51e-728e3a951a1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

