### PR TITLE
fix(shared): is:permanent parity with Scryfall (legacy Summon, Eaturecray, Token)

### DIFF
--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -71,7 +71,7 @@ export {
 export { NON_TOURNAMENT_MASK } from "./search/eval-printing";
 export { levenshteinDistance } from "./levenshtein";
 export { normalizeAlphanumeric } from "./normalize";
-export { IS_KEYWORDS } from "./search/eval-is";
+export { IS_KEYWORDS, typeLineIsPermanent } from "./search/eval-is";
 export { parse } from "./search/parser";
 export { escapeMarkdownLinkText, formatMarkdownInlineLink } from "./markdown-link";
 export { formatSlackCardReference } from "./slack-card-reference";

--- a/shared/src/search/eval-is.test.ts
+++ b/shared/src/search/eval-is.test.ts
@@ -5,6 +5,7 @@ import { parse } from "./parser";
 import { CardIndex } from "./card-index";
 import { Format } from "../bits";
 import type { ColumnarData } from "../data";
+import { typeLineIsPermanent } from "./eval-is";
 
 function minimalData(overrides: Partial<ColumnarData> & Pick<ColumnarData, "names">): ColumnarData {
   const n = overrides.names.length;
@@ -113,5 +114,31 @@ describe("evalIsKeyword partner superset", () => {
       oracle_texts: ["When The Eighth Doctor enters, mill three."],
     });
     expect(matchCount(data, "is:partner")).toBe(1);
+  });
+});
+
+describe("typeLineIsPermanent (Scryfall is:permanent parity)", () => {
+  test("matches modern permanent type words", () => {
+    expect(typeLineIsPermanent("creature — goblin")).toBe(true);
+    expect(typeLineIsPermanent("instant")).toBe(false);
+    expect(typeLineIsPermanent("sorcery")).toBe(false);
+  });
+
+  test("matches pre–sixth edition Summon lines (no 'creature' substring)", () => {
+    expect(typeLineIsPermanent("summon dragon")).toBe(true);
+    expect(typeLineIsPermanent("summon — specter")).toBe(true);
+    expect(typeLineIsPermanent("summon legend")).toBe(true);
+  });
+
+  test("matches Unhinged Eaturecray creature type line", () => {
+    expect(typeLineIsPermanent("eaturecray — igpay")).toBe(true);
+  });
+
+  test("matches oracle-only Token type line (Unstable Copy)", () => {
+    expect(typeLineIsPermanent("token")).toBe(true);
+  });
+
+  test("does not treat mid-string summon as legacy creature", () => {
+    expect(typeLineIsPermanent("instant — ritual of summoning")).toBe(false);
   });
 });

--- a/shared/src/search/eval-is.ts
+++ b/shared/src/search/eval-is.ts
@@ -9,6 +9,18 @@ import { CardFlag, Finish, Format, PrintingFlag, PROMO_TYPE_FLAGS } from "../bit
 
 const PERMANENT_TYPES = ["artifact", "battle", "creature", "enchantment", "land", "planeswalker"];
 
+/** True if type line denotes a permanent per Scryfall-style rules (incl. legacy wording). */
+export function typeLineIsPermanent(typeLineLower: string): boolean {
+  if (PERMANENT_TYPES.some(t => typeLineLower.includes(t))) return true;
+  // Pre–Sixth Edition creature wording ("Summon Dragon", etc.) — no "creature" substring.
+  if (typeLineLower.startsWith("summon")) return true;
+  // Unhinged creature pun type line ("Eaturecray — Pig", etc.).
+  if (typeLineLower.startsWith("eaturecray")) return true;
+  // Oracle card "Copy" (Unstable) — type line is exactly "Token"; still a permanent on the battlefield.
+  if (typeLineLower === "token") return true;
+  return false;
+}
+
 const DFC_LAYOUTS = new Set(["transform", "modal_dfc", "meld"]);
 
 const PARTY_TYPES = ["cleric", "rogue", "warrior", "wizard"];
@@ -283,7 +295,7 @@ export function evalIsKeyword(
   switch (keyword) {
     case "permanent":
       for (let i = 0; i < n; i++) {
-        if (PERMANENT_TYPES.some(t => index.typeLinesLower[i].includes(t))) buf[cf[i]] = 1;
+        if (typeLineIsPermanent(index.typeLinesLower[i])) buf[cf[i]] = 1;
       }
       break;
     case "spell":

--- a/shared/src/search/evaluator-is.test.ts
+++ b/shared/src/search/evaluator-is.test.ts
@@ -55,6 +55,9 @@ import { index, printingIndex, matchCountWithPrintings } from "./evaluator.test-
 // Row #38 Demonic Tutor             | B  | Sorcery                                 | -      cmc=2      | normal  flags=GameChanger
 // Row #43 Brisela (meld result)      | WB | Legendary Creature — Angel Horror       | pow=4 tou=3 cmc=7 | meld   flags=MeldResult (excluded from is:commander)
 // Row #44 Ransack (spell commander)  | B  | Sorcery                                 | -      cmc=2      | normal (oracle has "Spell commander" — can be commander)
+// Row #45 Legacy summon              | R  | Summon Dragon                           | 2/2    cmc=4      | normal (pre–Sixth Edition creature wording)
+// Row #46 Unhinged eaturecray        | -  | Eaturecray — Igpay                    | 2/2    cmc=3      | normal
+// Row #47 Oracle Copy token          | -  | Token                                   | -      cmc=0      | token  (type line exactly "Token" — still is:permanent)
 
 const isExtPowerDict = ["", "0", "*", "2", "3", "4", "1", "6"];
 const isExtToughnessDict = ["", "1", "1+*", "3", "4", "2", "6"];
@@ -84,6 +87,9 @@ const IS_TEST_DATA: ColumnarData = {
     "Gideon's Emblem",
     "Brisela, Voice of Nightmares",
     "Ransack, the Lab",
+    "Prismatic Dragon",
+    "Atinlay Igpay",
+    "Copy",
   ],
   mana_costs: [
     "{G}", "{R}", "{U}{U}", "{1}", "{1}{G}",
@@ -109,6 +115,9 @@ const IS_TEST_DATA: ColumnarData = {
     "",
     "{4}{W}{W}{W}",
     "{1}{B}",
+    "{2}{R}{R}",
+    "{3}",
+    "",
   ],
   oracle_texts: [
     "Flying (This creature can't be blocked except by creatures with flying or reach.)\n{T}: Add one mana of any color.",
@@ -156,6 +165,9 @@ const IS_TEST_DATA: ColumnarData = {
     "Creatures you control get +1/+1.",
     "Flying, first strike, lifelink",
     "Spell commander (This card can be your commander.)\nLook at the top three cards of your library.",
+    "Flying",
+    "Eaturecray spells you cast cost {2} less to cast.",
+    "You may have Copy enter the battlefield as a copy of any card on the battlefield.",
   ],
   colors: [
     Color.Green, Color.Red, Color.Blue, 0, Color.Green,
@@ -181,6 +193,9 @@ const IS_TEST_DATA: ColumnarData = {
     0,
     Color.White | Color.Black,
     Color.Black,
+    Color.Red,
+    0,
+    0,
   ],
   color_identity: [
     Color.Green, Color.Red, Color.Blue, 0, Color.Green,
@@ -206,6 +221,9 @@ const IS_TEST_DATA: ColumnarData = {
     0,
     Color.White | Color.Black,
     Color.Black,
+    Color.Red,
+    0,
+    0,
   ],
   type_lines: [
     "Creature — Elf",
@@ -253,21 +271,24 @@ const IS_TEST_DATA: ColumnarData = {
     "Emblem — Gideon",
     "Legendary Creature — Angel Horror",
     "Sorcery",
+    "Summon Dragon",
+    "Eaturecray — Igpay",
+    "Token",
   ],
-  //                              0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44
-  powers:      /* dict idx */   [ 1, 0, 0, 0, 2, 0, 3, 4, 5, 0, 3, 3, 6, 1, 3, 4, 3, 0, 0, 0, 0, 6, 4, 5, 6, 7, 0, 0, 4, 4, 0, 0, 0, 0, 0, 3, 6, 6, 0, 3, 0, 6, 0, 5, 0],
-  toughnesses: /* dict idx */   [ 1, 0, 0, 0, 2, 0, 1, 3, 4, 0, 5, 5, 1, 1, 3, 5, 3, 0, 0, 0, 0, 1, 5, 3, 5, 6, 0, 0, 3, 4, 0, 0, 0, 0, 0, 5, 3, 1, 0, 5, 0, 1, 0, 3, 0],
-  loyalties:                    [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-  defenses:                     [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-  legalities_legal:             [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-  legalities_banned:            [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-  legalities_restricted:        [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-  card_index:     [0, 1, 2, 3, 4, 5, 6, 7, 7, 8, 9, 10, 11, 12, 13, 14, 15, 15, 16, 16, 17, 18, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 41, 42, 43, 44],
-  canonical_face: [0, 1, 2, 3, 4, 5, 6, 7, 7, 9, 10, 11, 12, 13, 14, 15, 16, 16, 18, 18, 20, 21, 21, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44],
-  scryfall_ids:          Array(45).fill(""),
-  oracle_ids:            Array(45).fill(""),
-  art_crop_thumb_hashes: Array(45).fill(""),
-  card_thumb_hashes:     Array(45).fill(""),
+  //                              0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47
+  powers:      /* dict idx */   [ 1, 0, 0, 0, 2, 0, 3, 4, 5, 0, 3, 3, 6, 1, 3, 4, 3, 0, 0, 0, 0, 6, 4, 5, 6, 7, 0, 0, 4, 4, 0, 0, 0, 0, 0, 3, 6, 6, 0, 3, 0, 6, 0, 5, 0, 3, 3, 0],
+  toughnesses: /* dict idx */   [ 1, 0, 0, 0, 2, 0, 1, 3, 4, 0, 5, 5, 1, 1, 3, 5, 3, 0, 0, 0, 0, 1, 5, 3, 5, 6, 0, 0, 3, 4, 0, 0, 0, 0, 0, 5, 3, 1, 0, 5, 0, 1, 0, 3, 0, 5, 5, 0],
+  loyalties:                    [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  defenses:                     [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  legalities_legal:             [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  legalities_banned:            [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  legalities_restricted:        [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  card_index:     [0, 1, 2, 3, 4, 5, 6, 7, 7, 8, 9, 10, 11, 12, 13, 14, 15, 15, 16, 16, 17, 18, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 41, 42, 43, 44, 45, 46, 47],
+  canonical_face: [0, 1, 2, 3, 4, 5, 6, 7, 7, 9, 10, 11, 12, 13, 14, 15, 16, 16, 18, 18, 20, 21, 21, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47],
+  scryfall_ids:          Array(48).fill(""),
+  oracle_ids:            Array(48).fill(""),
+  art_crop_thumb_hashes: Array(48).fill(""),
+  card_thumb_hashes:     Array(48).fill(""),
   layouts: [
     "normal", "normal", "normal", "normal", "normal",
     "normal", "normal", "transform", "transform", "normal",
@@ -292,6 +313,9 @@ const IS_TEST_DATA: ColumnarData = {
     "emblem",
     "meld",
     "normal",
+    "normal",
+    "normal",
+    "token",
   ],
   flags: [
     0, 0, 0, 0, 0,
@@ -315,9 +339,12 @@ const IS_TEST_DATA: ColumnarData = {
     0, 0,
     CardFlag.MeldResult,
     0,
+    0,
+    0,
+    0,
   ],
-  edhrec_ranks: Array(45).fill(null) as (number | null)[],
-  edhrec_salts: Array(45).fill(null) as (number | null)[],
+  edhrec_ranks: Array(48).fill(null) as (number | null)[],
+  edhrec_salts: Array(48).fill(null) as (number | null)[],
   power_lookup: isExtPowerDict,
   toughness_lookup: isExtToughnessDict,
   loyalty_lookup: [""],
@@ -357,8 +384,15 @@ describe("is: operator", () => {
     expect(indices).toContain(30); // Steam Vents (Land)
   });
 
+  test("is:permanent matches legacy Summon, Eaturecray, and bare Token type lines (Scryfall parity)", () => {
+    const indices = isMatchIndices("is:permanent");
+    expect(indices).toContain(45); // Summon Dragon (past)
+    expect(indices).toContain(46); // Eaturecray — Igpay (Unhinged)
+    expect(indices).toContain(47); // Token (oracle Copy)
+  });
+
   test("is:spell matches non-land cards", () => {
-    expect(isMatchCount("is:spell")).toBe(35);
+    expect(isMatchCount("is:spell")).toBe(38);
   });
 
   test("is:historic matches artifacts, legendaries, and sagas", () => {
@@ -458,7 +492,7 @@ describe("is: operator", () => {
 
   test("is:token matches token layout", () => {
     const indices = isMatchIndices("is:token");
-    expect(indices).toEqual([41]); // Goblin Token
+    expect(indices).toEqual([41, 47]); // Goblin Token; oracle Copy (layout token, type line Token)
   });
 
   test("is:emblem matches emblem layout", () => {
@@ -709,7 +743,7 @@ describe("is: operator", () => {
     const indices = isMatchIndices("-is:funny");
     expect(indices).not.toContain(28);
     expect(indices).toContain(0); // Birds
-    expect(indices.length).toBe(40); // 41 unique canonical faces - 1 funny
+    expect(indices.length).toBe(43); // was 40; +3 new non-funny canonical faces for is:permanent parity fixtures
   });
 
   // --- Land cycle checks ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the remaining 13-card gap for `is:permanent include:extras` vs Scryfall (GitHub #215).

## Root cause

`is:permanent` only looked for modern type words (`creature`, `artifact`, etc.). Scryfall also counts:

1. **Pre–Sixth Edition creatures** whose oracle `type_line` uses **Summon** (e.g. `Summon Dragon`) with no `creature` substring — 11 oracle cards in bulk data.
2. **Unhinged** **Eaturecray** creature type lines (one card: Atinlay Igpay).
3. **Oracle card Copy** (Unstable): `type_line` is exactly **Token**; Scryfall still treats it as a permanent for this query.

## Change

- Added `typeLineIsPermanent()` in `eval-is.ts` and wired `is:permanent` through it.
- Exported from `@frantic-search/shared` for reuse/tests.
- Extended evaluator fixtures and unit tests.

## Verification

- `npm test -w shared` — all pass.
- `npm run cli -- diff "is:permanent include:extras" -q` — **In both** only, 0 discrepancies (against live Scryfall at time of run).

Suggested review: confirm we are comfortable matching Scryfall’s legacy-type heuristics rather than only CR-style `creature` wording.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c22fa1a-30bf-4463-ac41-7820ddc9ff08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c22fa1a-30bf-4463-ac41-7820ddc9ff08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

